### PR TITLE
Fix null exception when using something besides a steamer

### DIFF
--- a/DVMultiplayerContinued/Unity/Train/NetworkTrainManager.cs
+++ b/DVMultiplayerContinued/Unity/Train/NetworkTrainManager.cs
@@ -1774,6 +1774,9 @@ internal class NetworkTrainManager : SingletonBehaviour<NetworkTrainManager>
             return;
 
         SteamLocoSimulation steamSimulation = loco.GetComponentInChildren<SteamLocoSimulation>();
+        if (steamSimulation == null)
+            return;
+
         float fireOn = steamSimulation.fireOn.value;
         float coalInFireBox = steamSimulation.coalbox.value;
         float tenderCoal = steamSimulation.tenderCoal.value;


### PR DESCRIPTION
```
NullReferenceException: Object reference not set to an instance of an object
  at NetworkTrainManager.SendNewLocoValue (TrainCar loco) [0x00035] in <c174e142d74b484ea371072f12b74db6>:0
  at NetworkTrainSync.Update () [0x0004d] in <c174e142d74b484ea371072f12b74db6>:0
```
Due to the player's loco not having SteamLocoSimulation