### PR TITLE
Don't sync all cars in the train during every car's update

### DIFF
--- a/DVMultiplayerContinued/Unity/Train/NetworkTrainPosSync.cs
+++ b/DVMultiplayerContinued/Unity/Train/NetworkTrainPosSync.cs
@@ -481,7 +481,9 @@ internal class NetworkTrainPosSync : MonoBehaviour
                 trainCar.stress.EnableStress(false);
         }
 
-        if (hasLocalPlayerAuthority && ((velocity.magnitude * 3.6f > .2f && Vector3.Distance(transform.position - WorldMover.currentMove, newPos) > Mathf.Lerp(1e-4f, 1e-2f, velocity.magnitude * 3.6f / 50)) || Quaternion.Angle(transform.rotation, newRot) > 1e-2f))
+        if (hasLocalPlayerAuthority
+            && trainCar == trainCar.trainset.cars[0]
+            && ((velocity.magnitude * 3.6f > .1f && Vector3.Distance(transform.position - WorldMover.currentMove, newPos) > Mathf.Lerp(1e-4f, 1e-2f, velocity.magnitude * 3.6f / 50)) || Quaternion.Angle(transform.rotation, newRot) > 1e-2f))
         {
             if (!trainCar.stress.enabled)
                 trainCar.stress.EnableStress(true);


### PR DESCRIPTION
This had an n^2 bug where every moving car would sync the entire train it was part of. Now it only does that for the first car in the train (whatever car that happens to be)