### PR TITLE
Improve the handling of player colors

### DIFF
--- a/DVMP.DTO/Player/NPlayer.cs
+++ b/DVMP.DTO/Player/NPlayer.cs
@@ -1,6 +1,4 @@
 ﻿using DarkRift;
-using DVMultiplayer.Darkrift;
-using UnityEngine;
 
 namespace DVMultiplayer.DTO.Player
 {
@@ -10,7 +8,7 @@ namespace DVMultiplayer.DTO.Player
         public string Username { get; set; }
         public string[] Mods { get; set; }
         public bool IsLoaded { get; set; }
-        public string Color { get; set; }
+        public ushort Color { get; set; }
 
         public void Deserialize(DeserializeEvent e)
         {
@@ -18,7 +16,7 @@ namespace DVMultiplayer.DTO.Player
             Username = e.Reader.ReadString();
             Mods = e.Reader.ReadStrings();
             IsLoaded = e.Reader.ReadBoolean();
-            Color = e.Reader.ReadString();
+            Color = e.Reader.ReadUInt16();
         }
 
         public void Serialize(SerializeEvent e)

--- a/DVMP.DTO/Player/NPlayer.cs
+++ b/DVMP.DTO/Player/NPlayer.cs
@@ -8,7 +8,7 @@ namespace DVMultiplayer.DTO.Player
         public string Username { get; set; }
         public string[] Mods { get; set; }
         public bool IsLoaded { get; set; }
-        public ushort Color { get; set; }
+        public uint Color { get; set; }
 
         public void Deserialize(DeserializeEvent e)
         {
@@ -16,7 +16,7 @@ namespace DVMultiplayer.DTO.Player
             Username = e.Reader.ReadString();
             Mods = e.Reader.ReadStrings();
             IsLoaded = e.Reader.ReadBoolean();
-            Color = e.Reader.ReadUInt16();
+            Color = e.Reader.ReadUInt32();
         }
 
         public void Serialize(SerializeEvent e)

--- a/DVMultiplayerContinued/DVMultiplayerContinued.csproj
+++ b/DVMultiplayerContinued/DVMultiplayerContinued.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Unity\UI\InputButton.cs" />
     <Compile Include="Unity\UI\InputScreen.cs" />
     <Compile Include="Unity\UI\TextField.cs" />
+    <Compile Include="Utils\ColorTT.cs" />
     <Compile Include="Utils\Game\SavedPositions.cs" />
     <Compile Include="Utils\UGameObject.cs" />
     <Compile Include="Utils\UUI.cs" />

--- a/DVMultiplayerContinued/Settings.cs
+++ b/DVMultiplayerContinued/Settings.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Globalization;
 using UnityEngine;
 using UnityModManagerNet;
 
@@ -10,19 +6,46 @@ namespace DVMultiplayerContinued
 {
     public class Settings : UnityModManager.ModSettings, IDrawable
     {
-        public string ColorString = "#FFFFFF";
-        [Header("Each color value from 0 to 255.")]
-        [Draw("Player Color")]
         public Color32 Color = new Color32(255, 255, 255, 255);
 
-        public void OnChange()
+        public void Draw(UnityModManager.ModEntry modEntry)
         {
-            ColorString = ColorUtility.ToHtmlStringRGB(Color);
+            // Player color
+            GUILayout.Label("Each color value from 0 to 255");
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Player Color");
+            byte[] values = { Color.r, Color.g, Color.b };
+            string[] labels = { "Red", "Green", "Blue" };
+            if (DrawMutiByte(ref values, labels))
+                Color = new Color32(values[0], values[1], values[2], 255);
+            GUILayout.EndHorizontal();
         }
+
+        public void OnChange()
+        { }
 
         public override void Save(UnityModManager.ModEntry modEntry)
         {
             Save(this, modEntry);
+        }
+
+        private static bool DrawMutiByte(ref byte[] values, string[] labels)
+        {
+            bool modified = false;
+            byte[] arr = new byte[values.Length];
+            for (int index = 0; index < values.Length; ++index)
+            {
+                GUILayout.BeginHorizontal();
+                GUILayout.Label(labels[index], GUILayout.ExpandWidth(false));
+                string s = GUILayout.TextField(values[index].ToString(), GUI.skin.textField);
+                GUILayout.EndHorizontal();
+                arr[index] = byte.TryParse(s, NumberStyles.Any, NumberFormatInfo.CurrentInfo, out byte result) ? result : (byte)0;
+                if (arr[index] != values[index])
+                    modified = true;
+            }
+
+            values = arr;
+            return modified;
         }
     }
 }

--- a/DVMultiplayerContinued/Unity/Player/NetworkPlayerManager.cs
+++ b/DVMultiplayerContinued/Unity/Player/NetworkPlayerManager.cs
@@ -42,7 +42,7 @@ internal class NetworkPlayerManager : SingletonBehaviour<NetworkPlayerManager>
     }
 
 
-    private GameObject GetNewPlayerObject(Vector3 pos, Quaternion rotation, string username, ushort packedColor)
+    private GameObject GetNewPlayerObject(Vector3 pos, Quaternion rotation, string username, uint packedColor)
     {
         GameObject player = GameObject.CreatePrimitive(PrimitiveType.Capsule);
         player.name = username;

--- a/DVMultiplayerContinued/Unity/Player/NetworkPlayerManager.cs
+++ b/DVMultiplayerContinued/Unity/Player/NetworkPlayerManager.cs
@@ -42,7 +42,7 @@ internal class NetworkPlayerManager : SingletonBehaviour<NetworkPlayerManager>
     }
 
 
-    private GameObject GetNewPlayerObject(Vector3 pos, Quaternion rotation, string username, string hexColor)
+    private GameObject GetNewPlayerObject(Vector3 pos, Quaternion rotation, string username, ushort packedColor)
     {
         GameObject player = GameObject.CreatePrimitive(PrimitiveType.Capsule);
         player.name = username;
@@ -50,9 +50,7 @@ internal class NetworkPlayerManager : SingletonBehaviour<NetworkPlayerManager>
         player.transform.rotation = rotation;
         player.transform.localScale = new Vector3(0.7f, 1f, 0.7f);
         player.GetComponent<CapsuleCollider>().enabled = false;
-        ColorUtility.TryParseHtmlString(hexColor, out Color color);
-        if (color != null)
-            player.GetComponent<Renderer>().material.color = color;
+        player.GetComponent<Renderer>().material.color = ColorTT.Unpack(packedColor);
         player.AddComponent<NetworkPlayerSync>();
 
         GameObject nametagCanvas = new GameObject("Nametag Canvas");
@@ -400,7 +398,7 @@ internal class NetworkPlayerManager : SingletonBehaviour<NetworkPlayerManager>
                 Id = SingletonBehaviour<UnityClient>.Instance.ID,
                 Username = PlayerManager.PlayerTransform.GetComponent<NetworkPlayerSync>().Username,
                 Mods = Main.GetEnabledMods(),
-                Color = Main.Settings.ColorString
+                Color = Main.Settings.Color.Pack()
             });
 
             using (Message message = Message.Create((ushort)NetworkTags.PLAYER_INIT, writer))

--- a/DVMultiplayerContinued/Unity/Player/NetworkPlayerSync.cs
+++ b/DVMultiplayerContinued/Unity/Player/NetworkPlayerSync.cs
@@ -7,7 +7,7 @@ internal class NetworkPlayerSync : MonoBehaviour
     public bool IsLocal { get; set; } = false;
     public string Username { get; set; }
     public string[] Mods { get; set; }
-    public string Color { get; set; }
+    public ushort Color { get; set; }
     internal ushort Id;
     private Vector3 prevPosition;
     private Vector3 newPosition;

--- a/DVMultiplayerContinued/Unity/Player/NetworkPlayerSync.cs
+++ b/DVMultiplayerContinued/Unity/Player/NetworkPlayerSync.cs
@@ -7,7 +7,7 @@ internal class NetworkPlayerSync : MonoBehaviour
     public bool IsLocal { get; set; } = false;
     public string Username { get; set; }
     public string[] Mods { get; set; }
-    public ushort Color { get; set; }
+    public uint Color { get; set; }
     internal ushort Id;
     private Vector3 prevPosition;
     private Vector3 newPosition;

--- a/DVMultiplayerContinued/Utils/ColorTT.cs
+++ b/DVMultiplayerContinued/Utils/ColorTT.cs
@@ -4,21 +4,18 @@ namespace DVMultiplayer.Utils
 {
     public static class ColorTT
     {
-        public static ushort Pack(this Color32 color)
+        public static uint Pack(this Color32 color)
         {
-            ushort packed = 0;
-            packed |= (ushort)(color.r << 8);
-            packed |= color.g;
-            packed |= (ushort)(color.b >> 8);
-            return packed;
+            return ((uint)color.r << 24) | ((uint)color.g << 16) | ((uint)color.b << 8) | color.a;
         }
 
-        public static Color32 Unpack(ushort packedColor)
+        public static Color32 Unpack(uint packedColor)
         {
-            byte r = (byte)(packedColor >> 8);
-            byte g = (byte)(packedColor & 0xFF);
-            byte b = (byte)((packedColor << 8) >> 8);
-            return new Color32(r, g, b, 255);
+            byte r = (byte)(packedColor >> 24);
+            byte g = (byte)(packedColor >> 16);
+            byte b = (byte)(packedColor >> 8);
+            byte a = (byte)packedColor;
+            return new Color32(r, g, b, a);
         }
     }
 }

--- a/DVMultiplayerContinued/Utils/ColorTT.cs
+++ b/DVMultiplayerContinued/Utils/ColorTT.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+namespace DVMultiplayer.Utils
+{
+    public static class ColorTT
+    {
+        public static ushort Pack(this Color32 color)
+        {
+            ushort packed = 0;
+            packed |= (ushort)(color.r << 8);
+            packed |= color.g;
+            packed |= (ushort)(color.b >> 8);
+            return packed;
+        }
+
+        public static Color32 Unpack(ushort packedColor)
+        {
+            byte r = (byte)(packedColor >> 8);
+            byte g = (byte)(packedColor & 0xFF);
+            byte b = (byte)((packedColor << 8) >> 8);
+            return new Color32(r, g, b, 255);
+        }
+    }
+}

--- a/DVServerPlugins/PlayerPlugin/PlayerPlugin.cs
+++ b/DVServerPlugins/PlayerPlugin/PlayerPlugin.cs
@@ -225,7 +225,8 @@ namespace PlayerPlugin
                             {
                                 Id = player.Id,
                                 Username = player.Username,
-                                Mods = player.Mods
+                                Mods = player.Mods,
+                                Color = player.Color
                             });
 
                             writer.Write(new Location()
@@ -248,7 +249,8 @@ namespace PlayerPlugin
                                 Id = p.id,
                                 Username = p.username,
                                 Mods = p.mods,
-                                IsLoaded = p.isLoaded
+                                IsLoaded = p.isLoaded,
+                                Color = p.color,
                             });
 
                             writer.Write(new Location()
@@ -315,7 +317,7 @@ namespace PlayerPlugin
                     sender.Disconnect();
                 else
                 {
-                    players.Add(sender, new Player(player.Id, player.Username, player.Mods));
+                    players.Add(sender, new Player(player.Id, player.Username, player.Mods, player.Color));
                 }
             }
         }
@@ -400,11 +402,14 @@ namespace PlayerPlugin
         public Vector3 position;
         public Quaternion rotation;
         internal bool isLoaded;
-        public Player(ushort id, string username, string[] mods)
+        public readonly uint color;
+
+        public Player(ushort id, string username, string[] mods, uint color)
         {
             this.id = id;
             this.username = username;
             this.mods = mods;
+            this.color = color;
 
             isLoaded = false;
             position = new Vector3();


### PR DESCRIPTION
The settings menu has been redone to manually draw the color option, since the Draw attribute seems to be picky about when it works. With this, it's no longer backed by a HEX string.

When sending the color over the network, it's now packed into a uint.

This also fixes an issue where sometimes the color would be null and cause connections to fail, and an issue where colors weren't being synced properly.