### PR TITLE
Remove redundant PlayerPlugin Player object

### DIFF
--- a/DVMP.DTO/Player/NPlayer.cs
+++ b/DVMP.DTO/Player/NPlayer.cs
@@ -6,14 +6,29 @@ namespace DVMultiplayer.DTO.Player
     {
         public ushort Id { get; set; }
         public string Username { get; set; }
+        public Location Location { get; set; }
         public string[] Mods { get; set; }
         public bool IsLoaded { get; set; }
         public uint Color { get; set; }
+
+        public NPlayer()
+        { }
+        
+        public NPlayer(NPlayer player)
+        {
+            Id = player.Id;
+            Username = player.Username;
+            Location = player.Location;
+            Mods = player.Mods;
+            IsLoaded = player.IsLoaded;
+            Color = player.Color;
+        }
 
         public void Deserialize(DeserializeEvent e)
         {
             Id = e.Reader.ReadUInt16();
             Username = e.Reader.ReadString();
+            Location = e.Reader.ReadSerializable<Location>();
             Mods = e.Reader.ReadStrings();
             IsLoaded = e.Reader.ReadBoolean();
             Color = e.Reader.ReadUInt32();
@@ -23,6 +38,7 @@ namespace DVMultiplayer.DTO.Player
         {
             e.Writer.Write(Id);
             e.Writer.Write(Username);
+            e.Writer.Write(Location);
             e.Writer.Write(Mods);
             e.Writer.Write(IsLoaded);
             e.Writer.Write(Color);

--- a/DVMultiplayerContinued/Unity/Player/NetworkPlayerManager.cs
+++ b/DVMultiplayerContinued/Unity/Player/NetworkPlayerManager.cs
@@ -393,9 +393,9 @@ internal class NetworkPlayerManager : SingletonBehaviour<NetworkPlayerManager>
         Main.Log("[CLIENT] > PLAYER_INIT");
         using (DarkRiftWriter writer = DarkRiftWriter.Create())
         {
-            writer.Write<NPlayer>(new NPlayer()
-            {
+            writer.Write(new NPlayer {
                 Id = SingletonBehaviour<UnityClient>.Instance.ID,
+                Location = new Location(),
                 Username = PlayerManager.PlayerTransform.GetComponent<NetworkPlayerSync>().Username,
                 Mods = Main.GetEnabledMods(),
                 Color = Main.Settings.Color.Pack()
@@ -405,7 +405,7 @@ internal class NetworkPlayerManager : SingletonBehaviour<NetworkPlayerManager>
                 SingletonBehaviour<UnityClient>.Instance.SendMessage(message, SendMode.Reliable);
         }
 
-        Main.Log($"Wait for connection initializiation is finished");
+        Main.Log("Waiting for connection initialization to finish");
         SingletonBehaviour<CoroutineManager>.Instance.Run(WaitForInit());
     }
 
@@ -642,7 +642,7 @@ internal class NetworkPlayerManager : SingletonBehaviour<NetworkPlayerManager>
 
                 if (player.Id != SingletonBehaviour<UnityClient>.Instance.ID)
                 {
-                    Location playerPos = reader.ReadSerializable<Location>();
+                    Location playerPos = player.Location;
                     Main.Log($"[CLIENT] < PLAYER_SPAWN: Username: {player.Username} ");
                     if (IsSynced)
                         GameChat.PutSystemMessage($"{player.Username} has connected!");

--- a/DVServerPlugins/PlayerPlugin/PlayerPlugin.cs
+++ b/DVServerPlugins/PlayerPlugin/PlayerPlugin.cs
@@ -17,7 +17,7 @@ namespace PlayerPlugin
     public class PlayerPlugin : Plugin, IPluginSave
     {
         new public string Name { get; } = "PlayerPlugin";
-        private readonly Dictionary<IClient, Player> players = new Dictionary<IClient, Player>();
+        private readonly Dictionary<IClient, NPlayer> players = new Dictionary<IClient, NPlayer>();
         public SetSpawn playerSpawn { get; private set; }
         private double money;
         private IClient playerConnecting = null;
@@ -155,9 +155,9 @@ namespace PlayerPlugin
 
         private void SetPlayerLoaded(Message message, IClient sender)
         {
-            if (players.TryGetValue(sender, out Player player))
+            if (players.TryGetValue(sender, out NPlayer player))
             {
-                player.isLoaded = true;
+                player.IsLoaded = true;
                 ReliableSendToOthers(message, sender);
             }
             else
@@ -190,9 +190,9 @@ namespace PlayerPlugin
             bool succesfullyConnected = true;
             if (players.Count > 0)
             {
-                Player host = players.Values.First();
-                List<string> missingMods = GetMissingMods(host.mods, player.Mods);
-                List<string> extraMods = GetMissingMods(player.Mods, host.mods);
+                NPlayer host = players.Values.First();
+                List<string> missingMods = GetMissingMods(host.Mods, player.Mods);
+                List<string> extraMods = GetMissingMods(player.Mods, host.Mods);
                 if (missingMods.Count != 0 || extraMods.Count != 0)
                 {
                     succesfullyConnected = false;
@@ -221,17 +221,10 @@ namespace PlayerPlugin
                         Logger.Trace("[SERVER] > PLAYER_SPAWN");
                         using (DarkRiftWriter writer = DarkRiftWriter.Create())
                         {
-                            writer.Write(new NPlayer()
-                            {
-                                Id = player.Id,
-                                Username = player.Username,
-                                Mods = player.Mods,
-                                Color = player.Color
-                            });
-
-                            writer.Write(new Location()
-                            {
-                                Position = playerSpawn.Position
+                            writer.Write(new NPlayer(player) {
+                                Location = new Location {
+                                    Position = playerSpawn.Position
+                                }
                             });
                             using (Message outMessage = Message.Create((ushort)NetworkTags.PLAYER_SPAWN, writer))
                                 ReliableSendToOthers(outMessage, sender);
@@ -239,25 +232,12 @@ namespace PlayerPlugin
                     }
                     
                     // Announce other players to new player
-                    foreach (Player p in players.Values)
+                    foreach (NPlayer p in players.Values)
                     {
                         Logger.Trace("[SERVER] > PLAYER_SPAWN");
                         using (DarkRiftWriter writer = DarkRiftWriter.Create())
                         {
-                            writer.Write(new NPlayer()
-                            {
-                                Id = p.id,
-                                Username = p.username,
-                                Mods = p.mods,
-                                IsLoaded = p.isLoaded,
-                                Color = p.color,
-                            });
-
-                            writer.Write(new Location()
-                            {
-                                Position = p.position,
-                                Rotation = p.rotation
-                            });
+                            writer.Write(p);
 
                             using (Message outMessage = Message.Create((ushort)NetworkTags.PLAYER_SPAWN, writer))
                                 sender.SendMessage(outMessage, SendMode.Reliable);
@@ -317,7 +297,7 @@ namespace PlayerPlugin
                     sender.Disconnect();
                 else
                 {
-                    players.Add(sender, new Player(player.Id, player.Username, player.Mods, player.Color));
+                    players.Add(sender, player);
                 }
             }
         }
@@ -333,15 +313,13 @@ namespace PlayerPlugin
 
         private void LocationUpdateMessage(Message message, IClient sender)
         {
-            if (players.TryGetValue(sender, out Player player))
+            if (players.TryGetValue(sender, out NPlayer player))
             {
                 Location newLocation;
                 using (DarkRiftReader reader = message.GetReader())
                 {
                     newLocation = reader.ReadSerializable<Location>();
-                    player.position = newLocation.Position;
-                    if (newLocation.Rotation.HasValue)
-                        player.rotation = newLocation.Rotation.Value;
+                    player.Location = newLocation;
                 }
 
                 using (DarkRiftWriter writer = DarkRiftWriter.Create())
@@ -352,7 +330,6 @@ namespace PlayerPlugin
                     using (Message outMessage = Message.Create((ushort)NetworkTags.PLAYER_LOCATION_UPDATE, writer))
                         UnreliableSendToOthers(outMessage, sender);
                 }
-                
             }
         }
 
@@ -391,34 +368,6 @@ namespace PlayerPlugin
         {
             foreach (IClient client in ClientManager.GetAllClients().Where(client => client != sender))
                 client.SendMessage(message, SendMode.Reliable);
-        }
-    }
-
-    internal class Player
-    {
-        public readonly ushort id;
-        public readonly string username;
-        public readonly string[] mods;
-        public Vector3 position;
-        public Quaternion rotation;
-        internal bool isLoaded;
-        public readonly uint color;
-
-        public Player(ushort id, string username, string[] mods, uint color)
-        {
-            this.id = id;
-            this.username = username;
-            this.mods = mods;
-            this.color = color;
-
-            isLoaded = false;
-            position = new Vector3();
-            rotation = new Quaternion();
-        }
-
-        public override string ToString()
-        {
-            return $"Player '{username}'/{id}";
         }
     }
 }


### PR DESCRIPTION
Removes the redundant `Player` object in the PlayerPlugin module, and replaces it with `NPlayer`. The `Player`'s position/rotation fields have also been consolidated into a `Location` and re-added to `NPlayer`.